### PR TITLE
Add freeze to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /book/.quarto/
 /book/site_libs/
 /book/_site/
+/book/_freeze/
 /docs/
 **/*.quarto_ipynb


### PR DESCRIPTION
This PR adds the `_freeze` folder to `.gitignore`, as it contains outputs of local build we don't need here.