### PR TITLE
Use small dataset for pynapple section.

### DIFF
--- a/book/course-data.qmd
+++ b/book/course-data.qmd
@@ -27,7 +27,9 @@ or parts of it) using SpikeInterface. We will use it to download the dataset abo
 The NWB file for this dataset includes not only the raw electrophysiological data,
 but the results of spike sorting (spike times, units) and behavioral data from the experiment.
 
-For the Pynapple head-direction decoding task, we only need the sorting outputs and behavioral data. Therefore we use **this script LINK**  to remove the electrophysiolgoical and accelerometer from the full NWB file. The cut-down data is available in in the course repository at `book/data/pynapple/dandiset-000939-no-traces-full.nwb`.
+For the Pynapple head-direction decoding task, we only need the sorting outputs and behavioral data. 
+Therefore we use **this script LINK**  to remove the electrophysiological data and accelerometer from the full NWB file. 
+The cut-down data is available in in the course repository at `book/data/pynapple/dandiset-000939-no-traces-full.nwb`.
 
 # IBL Benchmark dataset
 *Used in Preprocessing (part 1).*

--- a/book/course-data.qmd
+++ b/book/course-data.qmd
@@ -22,6 +22,15 @@ The function found [here] **TODO: ADD LINK** can be used to download and save da
 or parts of it) using SpikeInterface. We will use it to download the dataset above, but the same approach works for any of the thousands of recordings hosted on DANDI.
 
 
+## Spike times and behavior used in the Pynapple section
+
+The full NWB file for this dataset includes not only the raw electrophysiological data,
+but the results of spike sorting (spike times, units) and behavioral data from the experiment.
+
+For the Pynapple decoding section, we only need the sorting outputs and behavioral data. Therefore,
+we use **this script LINK**  to remove the electrophysiolgoical data and accelerometer data for this
+section. The data is available in in the course repository at `book/data/pynapple/dandiset-000939-no-traces-full.nwb` 
+
 # IBL Benchmark dataset
 *Used in Preprocessing (part 1).*
 

--- a/book/course-data.qmd
+++ b/book/course-data.qmd
@@ -24,12 +24,10 @@ or parts of it) using SpikeInterface. We will use it to download the dataset abo
 
 ## Spike times and behavior used in the Pynapple section
 
-The full NWB file for this dataset includes not only the raw electrophysiological data,
+The NWB file for this dataset includes not only the raw electrophysiological data,
 but the results of spike sorting (spike times, units) and behavioral data from the experiment.
 
-For the Pynapple decoding section, we only need the sorting outputs and behavioral data. Therefore,
-we use **this script LINK**  to remove the electrophysiolgoical data and accelerometer data for this
-section. The data is available in in the course repository at `book/data/pynapple/dandiset-000939-no-traces-full.nwb` 
+For the Pynapple head-direction decoding task, we only need the sorting outputs and behavioral data. Therefore we use **this script LINK**  to remove the electrophysiolgoical and accelerometer from the full NWB file. The cut-down data is available in in the course repository at `book/data/pynapple/dandiset-000939-no-traces-full.nwb`.
 
 # IBL Benchmark dataset
 *Used in Preprocessing (part 1).*

--- a/book/pynapple.qmd
+++ b/book/pynapple.qmd
@@ -1110,9 +1110,15 @@ def stream_dandiset(dandiset_id, filepath):
 ## Your turn
 Now it is your turn!
 
-Start by streaming a single session from [this dataset](https://dandiarchive.org/dandiset/000939?search=000939&pos=1) on the DANDI archive, it contains recordings from head direction cells in the postsubiculum.
-Use the streaming function we provided in the data section!
-<span style="color:red">LINK TO PREVIOUS CHAPTERS</span>.
+We will compute head direction tuning curves in the postsubiculum, and use these to decode head direction from neural activity. We will use the same [dataset](course-data.qmd#head-direction-experiment-from-the-dandi-archive) we have
+been working with in the [preprocessing](preprocessing-steps-coding.qmd), [sorting](spike-sorting-coding.qmd) and [curation](curation.qmd) chapters.
+
+For this section, we will need a much larger segment of data than we previously used. Therefore, 
+we will use the `.nwb` file that contains already-computed spike times, as well has behavioural data,
+but has all electrophysiological recording and accelerometer data removed to keep the file size small.
+**TODO: ADD DOWNLOAD LINK**
+This dataset is included in the course data under book/data/pynapple/dandiset-000939-no-traces-full.nwb',
+for full details see [here](course-data.qmd#spike-times-and-behaviour-used-in-the-pynapple-section). 
 
 Then, try to compute head direction tuning curves, and use those to decode head direction from the population activity.
 

--- a/book/pynapple.qmd
+++ b/book/pynapple.qmd
@@ -9,7 +9,7 @@ Pynapple can do a lot more than what is covered in this chapter, take a look at 
 The only thing you'll need to follow along is a working Python environment with `pynapple` installed.  
 See the [setup section](setup.qmd#create-the-environment) on how to set up the course environment. 
 
-If you want to run by itself, just install Pynapple using:
+If you want to run this by itself, just install Pynapple using:
 ```python
 pip install pynapple
 ```
@@ -440,7 +440,7 @@ ax_spikes.set_yticks([])
 ax_spikes.spines['left'].set_visible(False)
 ax_spikes.spines['right'].set_visible(False)
 ax_spikes.spines['top'].set_visible(False)
-ax_count.plot(counts)
+ax_count.step(counts.times(), counts.values)
 ax_count.set_ylabel("count")
 ax_count.set_xlabel("time (s)")
 ax_count.spines['right'].set_visible(False)

--- a/book/pynapple.qmd
+++ b/book/pynapple.qmd
@@ -5,8 +5,9 @@ Pynapple is a python package for analysing neural data.
 The package is actively maintained by the Flatiron Institute's [neuroRSE team](https://neurorse.flatironinstitute.org/). 
 
 Pynapple can do a lot more than what is covered in this chapter, take a look at the [Pynapple documentation](https://pynapple.org/user_guide/03_core_methods.html) for more.   
+
 The only thing you'll need to follow along is a working Python environment with `pynapple` installed.
-<span style="color:red">LINK TO PREVIOUS CHAPTERS</span>.
+See the [setup section](setup.qmd#create-the-environment) on how to set up the course environment. 
 
 Open your favourite way of running Python, and follow along!
 
@@ -36,7 +37,7 @@ presently with the Flatiron Institute's neuroRSE team:
 ![](https://githubcard.com/pynapple-org/pynapple.svg)
 
 ## Goal
-Pynapple was designed to lie in between pre- and postprocessing.  
+Pynapple was designed to lie in between data processing and analysis.
 It contains functions facilitating alignment, wrangling, and performing basic neuroscientific analysis.
 
 <div class="timeline-horizontal">
@@ -1108,15 +1109,17 @@ def stream_dandiset(dandiset_id, filepath):
 ```
 
 ## Your turn
+
 Now it is your turn!
 
 We will compute head direction tuning curves in the postsubiculum, and use these to decode head direction from neural activity. We will use the same [dataset](course-data.qmd#head-direction-experiment-from-the-dandi-archive) we have
 been working with in the [preprocessing](preprocessing-steps-coding.qmd), [sorting](spike-sorting-coding.qmd) and [curation](curation.qmd) chapters.
 
-However to ensure the decoding is accurate we will need much more of data than we previously used. Therefore, we will use the full `.nwb` file for the session, that contains already-computed spike times, as well has behavioural data, but has all electrophysiological recording and accelerometer data removed to keep the file size small.
+However to ensure the decoding is accurate we will need much more of data than we previously used. 
+Therefore, we will use the full `.nwb` file for the session that contains already-computed spike times, as well has behavioural data. However, to keep the file size small all raw electrophysiological data and accelerometer data has been removed.
 **TODO: ADD DOWNLOAD LINK**
-This dataset is included in the course data under book/data/pynapple/dandiset-000939-no-traces-full.nwb',
-for full details see [here](course-data.qmd#spike-times-and-behaviour-used-in-the-pynapple-section). 
+This dataset is included in the course data under `book/data/pynapple/dandiset-000939-no-traces-full.nwb`,
+for full details see [here](course-data.qmd#spike-times-and-behavior-used-in-the-pynapple-section). 
 
 Then, try to compute head direction tuning curves, and use those to decode head direction from the population activity.
 

--- a/book/pynapple.qmd
+++ b/book/pynapple.qmd
@@ -1113,9 +1113,7 @@ Now it is your turn!
 We will compute head direction tuning curves in the postsubiculum, and use these to decode head direction from neural activity. We will use the same [dataset](course-data.qmd#head-direction-experiment-from-the-dandi-archive) we have
 been working with in the [preprocessing](preprocessing-steps-coding.qmd), [sorting](spike-sorting-coding.qmd) and [curation](curation.qmd) chapters.
 
-For this section, we will need a much larger segment of data than we previously used. Therefore, 
-we will use the `.nwb` file that contains already-computed spike times, as well has behavioural data,
-but has all electrophysiological recording and accelerometer data removed to keep the file size small.
+However to ensure the decoding is accurate we will need much more of data than we previously used. Therefore, we will use the full `.nwb` file for the session, that contains already-computed spike times, as well has behavioural data, but has all electrophysiological recording and accelerometer data removed to keep the file size small.
 **TODO: ADD DOWNLOAD LINK**
 This dataset is included in the course data under book/data/pynapple/dandiset-000939-no-traces-full.nwb',
 for full details see [here](course-data.qmd#spike-times-and-behaviour-used-in-the-pynapple-section). 

--- a/book/pynapple.qmd
+++ b/book/pynapple.qmd
@@ -13,7 +13,13 @@ If you want to run this by itself, just install Pynapple using:
 ```python
 pip install pynapple
 ```
-Then open your favourite way of running Python, and follow along!
+Then open your favourite way of running Python, import the right packages, and follow along!
+
+```{python}
+import matplotlib.pyplot as plt
+import numpy as np
+import pynapple as nap
+```
 
 ## Origins
 
@@ -111,8 +117,6 @@ It contains functions facilitating alignment, wrangling, and performing basic ne
 ### Time series (`Ts`)
 We store a time series, for example a spike train, in a `Ts` object.
 ```{python}
-
-import pynapple as nap
 ts = nap.Ts(t=[1,2,3,4,5])
 ts
 ```
@@ -120,7 +124,6 @@ ts
 #| code-fold: true
 #| code-summary: "Show plotting code"
 
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 for timepoint in ts.times():
     ax.axvline(timepoint)
@@ -136,8 +139,6 @@ plt.show()
 We store a time series with corresponding data values, for example the speed of a mouse when it is running around, in a `Tsd` object.
 
 ```{python}
-import pynapple as nap
-import numpy as np
 tsd = nap.Tsd(t=[1,2,3,4,5], d=[1,1,1,2,1])
 tsd
 ```
@@ -145,7 +146,6 @@ tsd
 #| code-fold: true
 #| code-summary: "Show plotting code"
 
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 ax.plot(tsd)
 ax.spines['top'].set_visible(False)
@@ -159,7 +159,6 @@ plt.show()
 If we have multiple time series, they can be collected in a `TsGroup`.  
 This could be a collection of spike times for multiple spiking units, for example.
 ```{python}
-import pynapple as nap
 tsgroup = nap.TsGroup({
     1: nap.Ts([1,2,3,4,5]), 
     2: nap.Ts([1.5, 2.2, 2.9, 4.2])
@@ -170,8 +169,6 @@ tsgroup
 #| code-fold: true
 #| code-summary: "Show plotting code"
 
-import matplotlib.pyplot as plt
-import numpy as np
 cmap = plt.get_cmap("tab10")
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 for i in tsgroup:
@@ -190,7 +187,6 @@ plt.show()
 If we have a time series with multiple data associated with the same time points, they can be stored in a `TsdFrame`.  
 This could be a collection of activity traces from multiple cells, e.g. recorded using [calcium-imaging](https://www.sciencedirect.com/science/article/pii/S0896627312001729).
 ```{python}
-import pynapple as nap
 tsdframe = nap.TsdFrame(
     t=[1,2,3,4,5], 
     d=[[1,2],
@@ -205,8 +201,6 @@ tsdframe
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
-import numpy as np
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 for i, col in enumerate(tsdframe.columns):
     ax.plot(tsdframe[:, i], label=col)
@@ -223,7 +217,6 @@ Often we want to store events that occur across a period rather than at single t
 for example a behavioural stimulus that lasts multiple seconds, or a period of sleep.
 To represent this, we store time intervals as start and end pairs in an `IntervalSet`.
 ```{python}
-import pynapple as nap
 epochs = nap.IntervalSet(
     start=[1, 3, 7],
     end=[2, 5, 9]
@@ -234,7 +227,6 @@ epochs
 #| code-fold: true
 #| code-summary: "Show plotting code"
 
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 for start, stop in epochs.values:
     ax.axvspan(start, stop)
@@ -253,14 +245,12 @@ for processing and analysis. Therefore, many Pynapple objects interact with each
 Every time series object has a time support, an `IntervalSet` that gives the epochs
 over which the time series is defined.
 ```{python}
-import pynapple as nap
 ts = nap.Ts(t=[1,2,3,4,5])
 ts.time_support
 ```
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 for timepoint in ts.times():
     ax.axvline(timepoint)
@@ -278,7 +268,6 @@ plt.show()
 Any time series object can be restricted to certain `IntervalSet`, thereby updating its time support.
 This could be used, for example, to keep only the spike times that fall within the presentation of a behavioural stimulus.
 ```{python}
-import pynapple as nap
 ts = nap.Ts(t=[1,2,3,4,5])
 restriction = nap.IntervalSet(start=[1.3, 3.9], end=[3.5, 4.2])
 restricted = ts.restrict(restriction)
@@ -287,7 +276,6 @@ restricted
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 for timepoint in restricted.times():
     ax.axvline(timepoint)
@@ -307,8 +295,6 @@ Given one time series, you can `value_from` to take the value corresponding
 to the closest time point in another time series with data.
 This can be handy, for example, if you want to sample the position of an animal, at particular spike times.
 ```{python}
-import pynapple as nap
-import numpy as np
 ts = nap.Ts(t=[1,2,3,4,5])
 tsd = nap.Tsd(t=np.arange(0, 10, 0.1), d=np.random.randn(100))
 values = ts.value_from(tsd)
@@ -317,7 +303,6 @@ values
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 ax.plot(tsd, label="tsd")
 ax.plot(values, label="values", linestyle="none", marker=".")
@@ -339,8 +324,6 @@ Pynapple objects are easy to transform, reshape, slice, and more.
 ### Numpy
 Most Numpy functions can be applied to Pynapple objects without hassle.
 ```{python}
-import pynapple as nap
-import numpy as np
 tsdframe = nap.TsdFrame(
     t=[1,2,3,4,5], 
     d=[[1,2],
@@ -354,8 +337,6 @@ np.mean(tsdframe, axis=1)
 ```
 ```{python}
 
-import pynapple as nap
-import numpy as np
 tsdframe = nap.TsdFrame(
     t=[1,2,3,4,5], 
     d=[[1,2],
@@ -371,8 +352,6 @@ np.diff(tsdframe, axis=1)
 ### Slicing
 Pynapple objects can be sliced like Numpy arrays.
 ```{python}
-import pynapple as nap
-import numpy as np
 tsdframe = nap.TsdFrame(
     t=[1,2,3,4,5], 
     d=[[1,2],
@@ -386,8 +365,6 @@ tsdframe[:, 1]
 ```
 ```{python}
 
-import pynapple as nap
-import numpy as np
 tsdframe = nap.TsdFrame(
     t=[1,2,3,4,5], 
     d=[[1,2],
@@ -407,8 +384,6 @@ The following are a subset of them, for an exhaustive list, see the [Pynapple do
 ### Binning
 The time points of any time series object can be counted.
 ```{python}
-import pynapple as nap
-import numpy as np
 time_step_s = 0.001
 times = np.arange(0, 4, time_step_s)
 
@@ -426,7 +401,6 @@ counts
 #| code-fold: true
 #| code-summary: "Show plotting code"
 
-import matplotlib.pyplot as plt
 fig, (ax_rate, ax_spikes, ax_count) = plt.subplots(
     3, 1, constrained_layout=True, figsize=(7.5,3), sharex=True
 )
@@ -452,8 +426,6 @@ plt.show()
 If you have continous data already, you would not count events in bins, but rather average values across bins.
 For example, if you wanted to downsample a signal without losing too much information.
 ```{python}
-import pynapple as nap
-import numpy as np
 time_step_s = 0.01
 times = np.arange(0, 10, time_step_s)
 
@@ -474,7 +446,6 @@ averaged
 #| code-fold: true
 #| code-summary: "Show plotting code"
 
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 plt.plot(tsd, label="original")
 plt.plot(averaged, label="averaged")
@@ -489,8 +460,6 @@ plt.show()
 ### Thresholding
 Time series with data can be thresholded, yielding new time series objects with updated time supports.
 ```{python}
-import pynapple as nap
-import numpy as np
 time_step_s = 0.01
 times = np.arange(0, 10, time_step_s)
 
@@ -512,7 +481,6 @@ above.time_support
 #| code-fold: true
 #| code-summary: "Show plotting code"
 
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 ax.plot(tsd, label="original")
 ax.plot(above, label="above", marker=".", linestyle="none")
@@ -528,8 +496,6 @@ Time series with data can be smoothed.
 Smoothing makes a signal less noisy by averaging out small, fast changes while keeping the main pattern.
 The operation consists of convolving the signal with a Gaussian kernel.
 ```{python}
-import pynapple as nap
-import numpy as np
 time_step_s = 0.01
 times = np.arange(0, 10, time_step_s)
 
@@ -550,7 +516,6 @@ smoothed
 #| code-fold: true
 #| code-summary: "Show plotting code"
 
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 ax.plot(tsd, label="original")
 ax.plot(smoothed, label="smoothed")
@@ -570,8 +535,6 @@ Given one or a group of time series, you can compute autocorrelograms.
 <span style="color:red">LINK TO PREVIOUS CHAPTERS</span>.
 
 ```{python}
-import pynapple as nap
-import numpy as np
 time_step_s = 0.01
 times = np.arange(0, 4, time_step_s)
 
@@ -594,7 +557,6 @@ autocorrelogram
 #| code-fold: true
 #| code-summary: "Show plotting code"
 
-import matplotlib.pyplot as plt
 ax=autocorrelogram.plot()
 plt.ylabel("rate (Hz)")
 plt.xlabel("time (s)")
@@ -614,7 +576,6 @@ crosscorrelogram
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 ax=crosscorrelogram.plot()
 plt.ylabel("rate (Hz)")
 plt.xlabel("time (s)")
@@ -629,8 +590,6 @@ Pynapple wraps a lot of scipy functions for signal processing.
 
 Let's simulate a noisy multi-frequency signal (the combination of multiple sine waves oscillating at different frequencies):
 ```{python}
-import pynapple as nap
-import numpy as np
 sampling_rate_hz = 1000
 times = np.linspace(0, 2, sampling_rate_hz * 2)
 
@@ -652,7 +611,6 @@ tsd
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 fig, (ax2, ax10, ax50, ax) = plt.subplots(
     4,
     1,
@@ -696,7 +654,6 @@ filtered
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 fig, (ax_original, ax_filtered) = plt.subplots(
     2,
     1,
@@ -731,7 +688,6 @@ psd
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(5,3))
 ax.plot(psd)
 ax.set_ylabel("power")
@@ -747,8 +703,6 @@ For example, spiking activity around a stimulus presentation.
 
 Let's start by simulating a spiking unit that has clear stimulus-locked activity:
 ```{python}
-import pynapple as nap
-import numpy as np
 stimuli = nap.Ts(t=np.arange(0, 1000, 1), time_units="s")
 baseline = np.random.uniform(0, 1000, 500)
 burst = np.concatenate([
@@ -763,7 +717,6 @@ ts
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 segment = nap.IntervalSet(100, 103.9)
 fig, ax = plt.subplots(1, 1, constrained_layout=True)
 ax.vlines(ts.restrict(segment).times(), 0.04, 0.10, label="spikes")
@@ -794,7 +747,6 @@ peth
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(figsize=(6, 4))
 ax.plot(peth.to_tsd(), "|", markersize=5)
 ax.set_ylabel("event")
@@ -821,11 +773,6 @@ In what follows, we'll simulate computing tuning curves from a circular variable
 
 Let's start by simulating some spiking units that are clearly modulated by a circular feature:
 ```{python}
-import pandas as pd
-import pynapple as nap
-import numpy as np
-from scipy.ndimage import gaussian_filter1d
-
 n_neurons = 6
 
 # Divide the circular feature space (0 to 2π) into bins
@@ -857,13 +804,8 @@ timestep = np.arange(total_timesteps) * time_step_sec
 # Modulo 2π keeps the feature within the circular range [0, 2π)
 feature = nap.Tsd(
     t=timestep,
-    d=(
-        gaussian_filter1d(
-            np.cumsum(np.random.randn(total_timesteps) * 0.5),
-            20
-        ) % (2*np.pi)
-    )
-)
+    d=np.cumsum(np.random.randn(total_timesteps) * 0.5),
+).smooth(0.2) % (2*np.pi)
 
 # Find which tuning curve bin corresponds to each feature value
 index = np.digitize(feature, bins) - 1
@@ -884,7 +826,6 @@ We now have a random walk in the feature space:
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(6, 4))
 ax.plot(feature.restrict(epochs), linestyle="none", marker="o")
 ax.set_yticks([0, 2*np.pi], ["0", "2π"])
@@ -899,7 +840,6 @@ As well as the activity of 6 neurons, modulated by the feature:
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 fig, ax = plt.subplots(constrained_layout=True, figsize=(6, 4))
 ax.plot(tsgroup.restrict(epochs).to_tsd(), linestyle="none", marker="|")
 ax.tick_params(axis="y", length=0)
@@ -971,7 +911,6 @@ and a `TsdFrame` containing the estimated probabilities of each feature value at
 ```{python}
 #| code-fold: true
 #| code-summary: "Show plotting code"
-import matplotlib.pyplot as plt
 fig, (ax1, ax2) = plt.subplots(figsize=(6, 5), nrows=2, ncols=1, sharex=True)
 ax1.plot(
     feature,
@@ -1040,8 +979,7 @@ Pynapple provides many ways to load your data.
 The main input format Pynapple can read is [Neurodata Without Borders (NWB)](https://nwb.org/).  
 Pynapple will parse all data in the file that can be represented as a Pynapple object and present a dictionary-like interface for selecting them.
 ```{python}
-#| code-fold: true
-#| code-summary: "Show plotting code"
+#| echo: false
 import os
 import requests
 nwb_path = 'A2929-200711.nwb'
@@ -1054,9 +992,7 @@ if nwb_path not in os.listdir("."):
         f.write(data)
 ```
 ```{python}
-import pynapple as nap
-nwb_path = 'A2929-200711.nwb'
-data = nap.load_file(nwb_path)
+data = nap.load_file('A2929-200711.nwb')
 data
 ```
 
@@ -1064,7 +1000,6 @@ data
 Raw data can be loaded with `pynapple` through the [NEO](https://neo.readthedocs.io/en/latest/) library (also used by SpikeInterface). 
 Many formats are supported, [see here](https://neo.readthedocs.io/en/stable/rawiolist.html).
 ```python
-import pynapple as nap
 data = nap.EphysReader("path/to/raw")
 ```
 
@@ -1072,8 +1007,6 @@ data = nap.EphysReader("path/to/raw")
 Pynapple objects can be saved (and loaded) as Numpy `.npz` files.
 
 ```{python}
-import pynapple as nap
-import numpy as np
 tsd = nap.Tsd(t=np.arange(10), d=np.arange(10))
 tsd.save("my_tsd.npz")
 loaded = nap.load_file("my_tsd.npz")
@@ -1084,7 +1017,6 @@ loaded
 Data in the NWB format can be directly streamed from the [DANDI archive](https://dandiarchive.org) into Pynapple.  
 Here is useful function to keep on hand that does this for you:
 ```{python}
-import pynapple as nap
 from pynwb import NWBHDF5IO
 from dandi.dandiapi import DandiAPIClient
 import fsspec

--- a/book/pynapple.qmd
+++ b/book/pynapple.qmd
@@ -6,10 +6,14 @@ The package is actively maintained by the Flatiron Institute's [neuroRSE team](h
 
 Pynapple can do a lot more than what is covered in this chapter, take a look at the [Pynapple documentation](https://pynapple.org/user_guide/03_core_methods.html) for more.   
 
-The only thing you'll need to follow along is a working Python environment with `pynapple` installed.
+The only thing you'll need to follow along is a working Python environment with `pynapple` installed.  
 See the [setup section](setup.qmd#create-the-environment) on how to set up the course environment. 
 
-Open your favourite way of running Python, and follow along!
+If you want to run by itself, just install Pynapple using:
+```python
+pip install pynapple
+```
+Then open your favourite way of running Python, and follow along!
 
 ## Origins
 
@@ -1078,7 +1082,7 @@ loaded
 
 ### Streaming from DANDI
 Data in the NWB format can be directly streamed from the [DANDI archive](https://dandiarchive.org) into Pynapple.  
-Here is useful function to keep handy that does this for you:
+Here is useful function to keep on hand that does this for you:
 ```{python}
 import pynapple as nap
 from pynwb import NWBHDF5IO
@@ -1115,13 +1119,11 @@ Now it is your turn!
 We will compute head direction tuning curves in the postsubiculum, and use these to decode head direction from neural activity. We will use the same [dataset](course-data.qmd#head-direction-experiment-from-the-dandi-archive) we have
 been working with in the [preprocessing](preprocessing-steps-coding.qmd), [sorting](spike-sorting-coding.qmd) and [curation](curation.qmd) chapters.
 
-However to ensure the decoding is accurate we will need much more of data than we previously used. 
-Therefore, we will use the full `.nwb` file for the session that contains already-computed spike times, as well has behavioural data. However, to keep the file size small all raw electrophysiological data and accelerometer data has been removed.
+However, to ensure the decoding is accurate we will need much more data than we previously used. 
+Therefore, we will use the full `.nwb` file for the session that contains pre-computed spike times, as well as behavioural data. 
 **TODO: ADD DOWNLOAD LINK**
 This dataset is included in the course data under `book/data/pynapple/dandiset-000939-no-traces-full.nwb`,
-for full details see [here](course-data.qmd#spike-times-and-behavior-used-in-the-pynapple-section). 
-
-Then, try to compute head direction tuning curves, and use those to decode head direction from the population activity.
+see [here](course-data.qmd#spike-times-and-behavior-used-in-the-pynapple-section) for more details. 
 
 If you are confident, you can write your own code using the snippets provided in this chapter.  
 If you want a bit more help, follow along in [this notebook](https://colab.research.google.com/drive/1o3IJtprvaTzwHxThGTdInE6GYADBULyA?usp=sharing).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "remfile",
     "scipy",
     "spikeinterface[full,widgets]",
+    "pynwb",
 ]
 
 [project.urls]

--- a/src/course_ephys_osss/data/utils.py
+++ b/src/course_ephys_osss/data/utils.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 import numpy as np
 from spikeinterface.extractors import NwbRecordingExtractor
-
+from pynwb import NWBHDF5IO
+from pynwb.ecephys import ElectricalSeries, LFP
 
 def download_and_slice_nwb_from_dandi(
     s3_url: str = "https://dandiarchive.s3.amazonaws.com/blobs/a8f/800/a8f8003e-4483-4b50-8a45-91ac5971f5d5",
@@ -82,9 +83,6 @@ def strip_recording_from_nwb(
     Path
         The path to the stripped NWB file.
     """
-    from pynwb import NWBHDF5IO
-    from pynwb.ecephys import ElectricalSeries, LFP
-
     nwb_path = Path(nwb_path)
 
     if output_path is None:

--- a/src/course_ephys_osss/data/utils.py
+++ b/src/course_ephys_osss/data/utils.py
@@ -50,3 +50,73 @@ def download_and_slice_nwb_from_dandi(
     )
 
     print(f"Saved {s3_url} to {local_folder}!")
+
+
+def strip_recording_from_nwb(
+    nwb_path: str | Path,
+    output_path: str | Path | None = None,
+    drop_interfaces: tuple[str, ...] = ("Accelerometer",),
+) -> Path:
+    """
+    Strip raw electrical series from an NWB file, keeping spike times and behaviour.
+
+    Removes all ``ElectricalSeries`` (raw/LFP traces) from acquisition and
+    processing modules, then writes a new NWB file containing everything else
+    (e.g. the ``units`` table and behavioural data). The kept data is copied
+    into the new file rather than linked back to the source.
+
+    Parameters
+    ----------
+    nwb_path : str | Path
+        Path to the source NWB file.
+    output_path : str | Path | None, default: None
+        Path to write the stripped NWB file. If None, ``_stripped`` is appended
+        to the source file name.
+    drop_interfaces : tuple[str, ...], default: ("Accelerometer",)
+        Names of additional processing data interfaces to drop (e.g. the large
+        raw ``Accelerometer`` stream). Pass an empty tuple to keep everything
+        except the electrical series.
+
+    Returns
+    -------
+    Path
+        The path to the stripped NWB file.
+    """
+    from pynwb import NWBHDF5IO
+    from pynwb.ecephys import ElectricalSeries, LFP
+
+    nwb_path = Path(nwb_path)
+
+    if output_path is None:
+        output_path = nwb_path.with_name(f"{nwb_path.stem}_stripped.nwb")
+    output_path = Path(output_path)
+
+    with NWBHDF5IO(str(nwb_path), mode="r") as read_io:
+        nwbfile = read_io.read()
+
+        # Drop raw traces stored directly in acquisition.
+        for name in list(nwbfile.acquisition.keys()):
+            if isinstance(nwbfile.acquisition[name], (ElectricalSeries, LFP)):
+                nwbfile.acquisition.pop(name)
+
+        # Drop traces stored inside processing modules (e.g. an 'ecephys' LFP),
+        # plus any explicitly requested interfaces (e.g. a large Accelerometer).
+        for module in nwbfile.processing.values():
+            for name in list(module.data_interfaces.keys()):
+                if name in drop_interfaces or isinstance(
+                    module[name], (ElectricalSeries, LFP)
+                ):
+                    module.data_interfaces.pop(name)
+
+        # link_data=False copies the kept data into the new file instead of
+        # linking back to the (large) source file.
+        with NWBHDF5IO(str(output_path), mode="w") as export_io:
+            export_io.export(
+                src_io=read_io,
+                nwbfile=nwbfile,
+                write_args={"link_data": False},
+            )
+
+    print(f"Saved stripped NWB to {output_path}!")
+
+    return output_path


### PR DESCRIPTION
This PR adds a cut back version of the full dandiset that has ephys data and accelerometer data removed (from ~24GB to 70MB) and adds instructions on how to access the data and how it was created.

We will also upload this data directly to zeneodo #15 currently it is just included in the repository (and will be removed eventually).

It also makes two other minor changes:

- links to set up in the introduction. BTW @wulfdewolf I think we had the pip install command here, but I think it's gone somehow, feel free to add it back!
- changed the terms preprocessing and postprocessing to processing and analysis to match the updated image