### PR TITLE
Fix website link and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,16 @@
 /docs/
 **/*.quarto_ipynb
 .vscode
+.idea/
 *.pyc
 *.egg
+*.egg-info/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
 
 book/my_tsd.npz
-/book/A2929-200711.nwb 
+/book/A2929-200711.nwb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSSS Extracellular Ephys 2026 Course
 
-The [website](https://neuroinformatics.dev/course-ephys-osss/) of the 2026 OSSS course. Currently in development, includes the [working plan](https://neuroinformatics.dev/course-ephys-osss/planning.html).
+The [website](https://neuroinformatics.dev/course_ephys_osss/) of the 2026 OSSS course. Currently in development, includes the [working plan](https://neuroinformatics.dev/course-ephys-osss/planning.html).
 
 # Contributing to the book
 The website is a Quarto book. GitHub Actions rebuilds it from `main` when changes are merged, and publishes the rendered site to the `gh-pages` branch for GitHub Pages to serve.


### PR DESCRIPTION
## Summary
- Ignore `.idea/`, `*.egg-info/`, and common macOS junk files (`.DS_Store`, etc.)
- Fix broken website URL in README (hyphenated slug)