### PR TITLE
Publish site on push to main, not only on tag

### DIFF
--- a/.github/workflows/quarto-docs.yml
+++ b/.github/workflows/quarto-docs.yml
@@ -2,8 +2,8 @@ name: Quarto Docs
 
 # Build the book on all merges to main, all pull requests, or by manual
 # workflow dispatch, which acts as a CI check that the book still renders.
-# The publish step only runs when a tag is pushed, deploying the already
-# rendered site to the gh-pages branch.
+# The publish step runs when changes land on main or a tag is pushed,
+# deploying the already rendered site to the gh-pages branch.
 on:
   push:
     branches:
@@ -51,7 +51,7 @@ jobs:
         run: quarto render book
 
       - name: Publish to gh-pages
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || github.ref == 'refs/heads/main'
         uses: quarto-dev/quarto-actions/publish@v2
         with:
           target: gh-pages

--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ quarto render --to html
 
 This generates the website in `book/_site`. After a PR is merged into `main`, CI rebuilds the site and publishes it to `gh-pages` automatically.
 
+## Releasing a new version
+
+The package version is not set manually: it is derived from git tags via `setuptools-scm` (see `pyproject.toml`). To cut a new release:
+
+```
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Pushing the tag triggers the same GitHub Actions workflow, which rebuilds and publishes the site to `gh-pages`, and `setuptools-scm` picks up `vX.Y.Z` as the new package version.
+


### PR DESCRIPTION
## Summary
- PR #87 gated the `Publish to gh-pages` step on tag pushes only, but the README still describes merge-to-main as auto-publishing the site. This restores that behaviour by also running the publish step on push to `main`.
- Documents the tag-based release process (bump via `git tag vX.Y.Z`) in the README, since the package version is derived from tags via `setuptools-scm`.